### PR TITLE
Price increment mobile

### DIFF
--- a/src/app/tabs/registrar/components/CommitComponent.js
+++ b/src/app/tabs/registrar/components/CommitComponent.js
@@ -21,8 +21,7 @@ class CommitComponent extends Component {
         <Row>
           <Col md={6} className="offset-md-3">
             <p>
-              2.
-              {strings.process_step_1_explanation}
+              {`2. ${strings.process_step_1_explanation}`}
             </p>
           </Col>
         </Row>

--- a/src/app/tabs/registrar/components/CommitComponent.js
+++ b/src/app/tabs/registrar/components/CommitComponent.js
@@ -43,9 +43,11 @@ class CommitComponent extends Component {
         </Row>
         <Row>
           <Col md={8} className="offset-md-2">
-            <i>
-              {strings.process_step_2_explanation}
-            </i>
+            <p>
+              <em>
+                {strings.process_step_2_explanation}
+              </em>
+            </p>
           </Col>
         </Row>
       </Container>

--- a/src/app/tabs/registrar/components/RentalPeriodComponent.js
+++ b/src/app/tabs/registrar/components/RentalPeriodComponent.js
@@ -75,7 +75,7 @@ class RentalPeriodComponent extends Component {
     return (
       <div>
         <p>
-          1. For how long do you want your name?
+          {`1. ${strings.how_long_want_name} ?`}
           <br />
         </p>
         {counter}
@@ -96,6 +96,7 @@ RentalPeriodComponent.propTypes = {
     rental_period: propTypes.string.isRequired,
     discount: propTypes.string.isRequired,
     price: propTypes.string.isRequired,
+    how_long_want_name: propTypes.string.isRequired,
   }).isRequired,
   getting: propTypes.bool.isRequired,
   rifCost: propTypes.number,

--- a/src/app/tabs/registrar/components/RentalPeriodComponent.js
+++ b/src/app/tabs/registrar/components/RentalPeriodComponent.js
@@ -52,8 +52,8 @@ class RentalPeriodComponent extends Component {
 
     const counter = (
       <div>
-        <Row className="justify-content-md-center">
-          <Col xs="2">
+        <Row className="justify-content-center">
+          <Col xs="4" lg="3">
             {strings.rental_period}
             <InputGroup>
               <InputGroup.Append>

--- a/src/app/tabs/registrar/components/RevealComponent.js
+++ b/src/app/tabs/registrar/components/RevealComponent.js
@@ -113,8 +113,7 @@ class RevealComponent extends Component {
             : (
               <div>
                 <p>
-                  3.
-                  {strings.process_step_3_explanation}
+                  {`3. ${strings.process_step_3_explanation}`}
                 </p>
                 <Button
                   disabled={!committed || waiting || revealed}

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -212,5 +212,6 @@
   "renew_domain_successfully": "the domain has been renewed succesfully",
   "discount": "50% discount per year from the third year",
   "rif_per_year": "RIF per year",
-  "price": "price"
+  "price": "price",
+  "how_long_want_name": "For how long do you want your name"
 }


### PR DESCRIPTION
This PR contains a few different styling and consistency issues on the Register page.

- Fix mobile issue with +/- counter
- Added Language definition. This may result in a "conflict" with the add-price-on-search branch when merging.
- Added space after the period in steps 2 and 3. I am unsure if this is the standard of if I should have created the space on a new line with `{' '}`.
- Changed `<i>` to `<em>` tag and wrapped text in a `<p>` tag.
