### PR TITLE
Indicator light no wallet

### DIFF
--- a/src/app/components/IndicatorLight.js
+++ b/src/app/components/IndicatorLight.js
@@ -6,9 +6,25 @@ import { multilanguage } from 'redux-multilanguage';
 import { networkSelector } from '../selectors';
 
 const IndicatorLight = (props) => {
-  const { networkMatch, network, strings } = props;
-  const className = (networkMatch) ? 'btn-outline-success' : 'btn-outline-danger';
-  const popup = (networkMatch) ? strings.connected_successful : `${strings.connect_to_network} ${networkSelector(network)}`;
+  const {
+    networkMatch,
+    network,
+    strings,
+    hasMetamask,
+  } = props;
+
+  let className = 'btn-outline-success';
+  let popup = strings.connected_successful;
+  let networkString = networkSelector(network);
+
+  if (!hasMetamask) {
+    className = 'btn-outline-warning';
+    popup = strings.no_wallet;
+  } else if (!networkMatch) {
+    className = 'btn-outline-danger';
+    popup = `${strings.connect_to_network} ${networkSelector(network)}`;
+    networkString = strings.unknown_network;
+  }
 
   return (
     <div className={`indicator btn disabled ${className}`}>
@@ -22,7 +38,7 @@ const IndicatorLight = (props) => {
         )}
       >
         <span>
-          {(networkMatch) ? networkSelector(network) : strings.unknown_network}
+          {networkString}
         </span>
       </OverlayTrigger>
     </div>
@@ -32,6 +48,7 @@ const IndicatorLight = (props) => {
 IndicatorLight.propTypes = {
   networkMatch: propTypes.bool.isRequired,
   network: propTypes.string.isRequired,
+  hasMetamask: propTypes.string.isRequired,
   strings: propTypes.shape().isRequired,
 };
 

--- a/src/app/components/IndicatorLight.js
+++ b/src/app/components/IndicatorLight.js
@@ -12,6 +12,7 @@ const IndicatorLight = (props) => {
     network,
     strings,
     hasMetamask,
+    walletUnlocked,
   } = props;
 
   let className = 'btn-outline-success';
@@ -21,6 +22,9 @@ const IndicatorLight = (props) => {
   if (!hasMetamask) {
     className = 'btn-outline-warning';
     popup = strings.no_wallet;
+  } else if (!walletUnlocked) {
+    className = 'btn-outline-warning';
+    popup = strings.unlock_wallet;
   } else if (!networkMatch) {
     className = 'btn-outline-danger';
     popup = `${strings.connect_to_network} ${networkSelector(network)}`;
@@ -52,6 +56,7 @@ IndicatorLight.propTypes = {
   networkMatch: propTypes.bool.isRequired,
   network: propTypes.string.isRequired,
   hasMetamask: propTypes.string.isRequired,
+  walletUnlocked: propTypes.string.isRequired,
   strings: propTypes.shape().isRequired,
 };
 

--- a/src/app/components/IndicatorLight.js
+++ b/src/app/components/IndicatorLight.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { multilanguage } from 'redux-multilanguage';
@@ -26,7 +27,7 @@ const IndicatorLight = (props) => {
     networkString = strings.unknown_network;
   }
 
-  return (
+  const body = (
     <div className={`indicator btn disabled ${className}`}>
       <OverlayTrigger
         key="bottom"
@@ -43,6 +44,8 @@ const IndicatorLight = (props) => {
       </OverlayTrigger>
     </div>
   );
+
+  return hasMetamask ? body : <Link to="/setup">{body}</Link>;
 };
 
 IndicatorLight.propTypes = {

--- a/src/app/containers/IndicatorLight.js
+++ b/src/app/containers/IndicatorLight.js
@@ -3,6 +3,7 @@ import { IndicatorLight } from '../components';
 
 const mapStateToProps = state => ({
   networkMatch: state.auth.networkMatch,
+  hasMetamask: state.auth.hasMetamask,
   network: process.env.REACT_APP_ENVIRONMENT_ID,
 });
 

--- a/src/app/containers/IndicatorLight.js
+++ b/src/app/containers/IndicatorLight.js
@@ -4,6 +4,7 @@ import { IndicatorLight } from '../components';
 const mapStateToProps = state => ({
   networkMatch: state.auth.networkMatch,
   hasMetamask: state.auth.hasMetamask,
+  walletUnlocked: state.auth.walletUnlocked,
   network: process.env.REACT_APP_ENVIRONMENT_ID,
 });
 

--- a/src/assets/css/sass/_header.scss
+++ b/src/assets/css/sass/_header.scss
@@ -27,6 +27,10 @@
   }
 }
 
+a:hover .indicator.btn-outline-warning {
+  color: #a07800;
+}
+
 .indicator.btn-outline-danger {
   span::before {
     background-color:#dc3545;

--- a/src/assets/css/sass/_header.scss
+++ b/src/assets/css/sass/_header.scss
@@ -20,6 +20,13 @@
   }
 }
 
+.indicator.btn-outline-warning {
+  color: #000000;
+  span::before {
+    background-color: #ffc107;
+  }
+}
+
 .indicator.btn-outline-danger {
   span::before {
     background-color:#dc3545;

--- a/src/languages/es_uy.json
+++ b/src/languages/es_uy.json
@@ -215,5 +215,6 @@
   "connect_to_network": "Conecte su wallet a",
   "current_connected": "Actualmente su wallet está conectada a",
   "connected_successful": "Conectado correctamente",
-  "unknown_network": "Red desconocida"
+  "unknown_network": "Red desconocida",
+  "unlock_wallet": "Desbloquee su wallet"
 }

--- a/src/languages/ja.json
+++ b/src/languages/ja.json
@@ -215,5 +215,6 @@
   "connect_to_network": "ウォレットを次に接続します：",
   "current_connected": "あなたのウォレットは現在、次に接続されています：",
   "connected_successful": "接続が無事完了しました",
-  "unknown_network": "未知のネットワーク"
+  "unknown_network": "未知のネットワーク",
+  "unlock_wallet": "ウォレットのロックを解除します"
 }

--- a/src/languages/ko.json
+++ b/src/languages/ko.json
@@ -215,5 +215,6 @@
   "connect_to_network": "지갑을 연결하십시오",
   "current_connected": "귀하의 지갑은 현재 연결되어 있습니다.",
   "connected_successful": "성공적으로 연결됨",
-  "unknown_network": "알 수 없는 네트워크"
+  "unknown_network": "알 수 없는 네트워크",
+  "unlock_wallet": "지갑을 잠금 해제"
 }

--- a/src/languages/pt_br.json
+++ b/src/languages/pt_br.json
@@ -215,5 +215,6 @@
   "connect_to_network": "Conecte sua carteira a",
   "current_connected": "Sua carteira está atualmente conectada a",
   "connected_successful": "Conexão realizada com sucesso",
-  "unknown_network": "Rede desconhecida"
+  "unknown_network": "Rede desconhecida",
+  "unlock_wallet": "Desbloqueie sua carteira"
 }

--- a/src/languages/ru.json
+++ b/src/languages/ru.json
@@ -215,5 +215,6 @@
   "connect_to_network": "Подключите свой кошелек к",
   "current_connected": "Ваш кошелек в настоящее время подключен к",
   "connected_successful": "Успешно подключено",
-  "unknown_network": "Неизвестная сеть"
+  "unknown_network": "Неизвестная сеть",
+  "unlock_wallet": "Пожалуйста, разблокируйте свой кошелек"
 }

--- a/src/languages/zh_cn.json
+++ b/src/languages/zh_cn.json
@@ -215,5 +215,6 @@
   "connect_to_network": "将您的钱包连接到",
   "current_connected": "您的钱包当前已连接至",
   "connected_successful": "连接成功",
-  "unknown_network": "未知网络"
+  "unknown_network": "未知网络",
+  "unlock_wallet": "解锁你的钱包"
 }


### PR DESCRIPTION
Adds a third state to the indicator light: no wallet. 

**Only shows when no wallet (metamask, or nifty) is detected**

![image](https://user-images.githubusercontent.com/766679/74038701-426e4b00-49c9-11ea-9760-e81e96294f81.png)

**On hover, a message is shown, using existing language, and when clicked, takes you to the setup page**

![image](https://user-images.githubusercontent.com/766679/74038772-5d40bf80-49c9-11ea-8701-6b856b43f785.png)
