### PR TITLE
Clear the registration process when clicking 'registration'

### DIFF
--- a/src/app/tabs/search/components/DomainStateComponent.js
+++ b/src/app/tabs/search/components/DomainStateComponent.js
@@ -9,7 +9,7 @@ import { isValidName } from '../../../validations';
 import { RegisterProcessContainer } from '../../../containers';
 
 // eslint-disable-next-line max-len
-function getDisplayState(domain, domainStateLoading, owned, blocked, owner, requestingOwner, requestingCost, rifCost, strings) {
+function getDisplayState(domain, domainStateLoading, owned, blocked, owner, requestingOwner, requestingCost, rifCost, registerDomain, strings) {
   if (!domain) return 'Search for a domain.';
   if (domainStateLoading || requestingCost || requestingOwner) {
     return <Spinner animation="grow" variant="primary" />;
@@ -41,7 +41,11 @@ function getDisplayState(domain, domainStateLoading, owned, blocked, owner, requ
     <>
       <p>{strings.open}</p>
       <p>
-        <Link to={`/registrar?domain=${domain}`} className="btn btn-primary">{strings.register_your_domain}</Link>
+        <Button
+          onClick={() => registerDomain(domain)}
+        >
+          {strings.register_your_domain}
+        </Button>
       </p>
       <p>
         {`${rifCost} ${strings.rif_per_year}`}
@@ -107,7 +111,7 @@ class DomainStateComponent extends Component {
   render() {
     const {
       strings, domain, owned, domainStateLoading, blocked, owner, requestingOwner,
-      requestingCost, rifCost,
+      requestingCost, rifCost, registerDomain,
     } = this.props;
     const { searchValue, invalid, showProcess } = this.state;
 
@@ -119,7 +123,7 @@ class DomainStateComponent extends Component {
 
     const displayState = getDisplayState(
       domain, domainStateLoading, owned, blocked, owner, requestingOwner, requestingCost,
-      rifCost, strings,
+      rifCost, registerDomain, strings,
     );
 
     return (
@@ -197,6 +201,7 @@ DomainStateComponent.propTypes = {
   search: propTypes.func.isRequired,
   requestingCost: propTypes.bool.isRequired,
   rifCost: propTypes.number.isRequired,
+  registerDomain: propTypes.func.isRequired,
 };
 
 DomainStateComponent.defaultProps = {

--- a/src/app/tabs/search/containers/DomainStateContainer.js
+++ b/src/app/tabs/search/containers/DomainStateContainer.js
@@ -3,6 +3,7 @@ import { push } from 'connected-react-router';
 import { parse } from 'query-string';
 import { DomainStateComponent } from '../components';
 import getDomainState from '../operations';
+import { resetRegistrarState } from '../../registrar/actions';
 
 const mapStateToProps = state => ({
   domain: parse(state.router.location.search).domain || '',
@@ -18,6 +19,10 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   getState: domain => dispatch(getDomainState(domain)),
   search: domain => dispatch(push(`/search?domain=${domain}`)),
+  registerDomain: (domain) => {
+    dispatch(resetRegistrarState());
+    dispatch(push(`/registrar?domain=${domain}`));
+  },
 });
 
 export default connect(


### PR DESCRIPTION
This PR allows a user to commit to a domain but not register. Then search for a second domain and when clicking register, resets the registration process back to step 1.

The salt remains for domains that have been committed but not registered. So, if a user commits a domain, then searches and commits a second, the user can still go back to the original domain and will see that the commit process was saved.

Ref #155 