### PR TITLE
Handle autologin error

### DIFF
--- a/src/app/auth/operations.js
+++ b/src/app/auth/operations.js
@@ -84,6 +84,8 @@ export const start = callback => (dispatch) => {
       .then(() => callback && callback())
       .catch(e => dispatch(errorEnable(e.message)));
   }
+
+  window.ethereum.on('accountsChanged', () => dispatch(start()));
 };
 
 export const logoutManager = () => (dispatch) => {

--- a/src/app/auth/operations.js
+++ b/src/app/auth/operations.js
@@ -12,6 +12,7 @@ import {
   errorLogin,
   errorEnable,
   logOut,
+  closeModal,
 } from './actions';
 
 export const authenticate = (name, address, noRedirect) => (dispatch) => {
@@ -40,10 +41,8 @@ export const authenticate = (name, address, noRedirect) => (dispatch) => {
       if (error) return resolve(dispatch(errorLogin(error)));
 
       if (address !== result) {
-        if (!noRedirect) {
-          return resolve(dispatch(receiveLogin(name, false)));
-        }
-        return null;
+        localStorage.removeItem('name');
+        return resolve(dispatch(receiveLogin(name, false)));
       }
 
       dispatch(checkResolver(name));
@@ -54,6 +53,7 @@ export const authenticate = (name, address, noRedirect) => (dispatch) => {
 
       localStorage.setItem('name', name);
 
+      dispatch(closeModal());
       return resolve(dispatch(receiveLogin(name, true)));
     });
   });

--- a/src/app/auth/reducer.js
+++ b/src/app/auth/reducer.js
@@ -67,7 +67,6 @@ export default (state = initialState, action) => {
       name: action.name,
       storageName: action.name,
       isOwner: action.isOwner,
-      showModal: !action.isOwner,
     };
     case types.ERROR_LOGIN: return {
       ...state,


### PR DESCRIPTION
Rather than returning null with no autoredirect, return false. However, only change the state of showModal if the result is true.

This allows for autologin to work, and when it fails, it allows the user to click login and use different credentials. 

Finally, on Metamask, we listen for the accountsChanged event and we run start() to get the current account. This listener is not available in Nifty. 

Closes #176 
Closes #154 

