### PR TITLE
Save array of previous logged in domains.

### DIFF
--- a/src/app/auth/operations.js
+++ b/src/app/auth/operations.js
@@ -15,6 +15,15 @@ import {
   closeModal,
 } from './actions';
 
+export const saveDomainToLocalStorage = (domain) => {
+  let storedDomains = JSON.parse(localStorage.getItem('domains'));
+  if (!storedDomains) storedDomains = [];
+  if (!storedDomains.includes(domain)) {
+    storedDomains.push(domain);
+    localStorage.setItem('domains', JSON.stringify(storedDomains));
+  }
+};
+
 export const authenticate = (name, address, noRedirect) => (dispatch) => {
   dispatch(requestLogin());
 
@@ -52,6 +61,7 @@ export const authenticate = (name, address, noRedirect) => (dispatch) => {
       }
 
       localStorage.setItem('name', name);
+      saveDomainToLocalStorage(name);
 
       dispatch(closeModal());
       return resolve(dispatch(receiveLogin(name, true)));

--- a/src/app/auth/operations.js
+++ b/src/app/auth/operations.js
@@ -16,8 +16,8 @@ import {
 } from './actions';
 
 export const saveDomainToLocalStorage = (domain) => {
-  let storedDomains = JSON.parse(localStorage.getItem('domains'));
-  if (!storedDomains) storedDomains = [];
+  const storedDomains = localStorage.getItem('domains')
+    ? JSON.parse(localStorage.getItem('domains')) : [];
   if (!storedDomains.includes(domain)) {
     storedDomains.push(domain);
     localStorage.setItem('domains', JSON.stringify(storedDomains));


### PR DESCRIPTION
Creates new localStorage item for domains that is an array for all of the previous domains. LocalStorage variable `name` still exists and is used for auto-login which still gets removed on logout.

Closes #216