### PR TITLE
Subdomain clear bug

### DIFF
--- a/src/app/tabs/newAdmin/subdomains/operations.js
+++ b/src/app/tabs/newAdmin/subdomains/operations.js
@@ -13,6 +13,8 @@ import {
   removeSubdomainFromList,
 } from './actions';
 
+import { sendBrowserNotification } from '../../../browerNotifications/operations';
+
 const web3 = new Web3(window.ethereum);
 
 // JS library:
@@ -56,6 +58,7 @@ const registerSubdomain = (parentDomain, subdomain, newOwner) => async (dispatch
         dispatch(addSubdomainToList(subdomain, newOwner));
         dispatch(receiveNewSubdomain(result));
         updateSubdomainToLocalStorage(parentDomain, subdomain, true);
+        sendBrowserNotification(`${subdomain}.${parentDomain}`, 'register_subdomain');
       };
 
       return dispatch(transactionListener(result, () => transactionConfirmed()));
@@ -154,8 +157,11 @@ export const setSubdomainOwner = (
         dispatch(receiveSetSubdomainOwner(result, subdomain, newOwner));
 
         if (newOwner === '0x0000000000000000000000000000000000000000') {
+          sendBrowserNotification(`${subdomain}.${parentDomain}`, 'remove_subdomain');
           updateSubdomainToLocalStorage(parentDomain, subdomain, false);
           dispatch(removeSubdomainFromList(subdomain));
+        } else {
+          sendBrowserNotification(`${subdomain}.${parentDomain}`, 'update_subdomain');
         }
       };
 

--- a/src/app/tabs/newAdmin/subdomains/operations.js
+++ b/src/app/tabs/newAdmin/subdomains/operations.js
@@ -68,7 +68,9 @@ const getSubdomainOwner = (domain, subdomain) => async (dispatch) => {
   await rns.compose();
   await rns.contracts.registry.methods.owner(hash).call((error, result) => {
     if (!error) {
-      dispatch(addSubdomainToList(subdomain, result));
+      if (result !== '0x0000000000000000000000000000000000000000') {
+        dispatch(addSubdomainToList(subdomain, result));
+      }
     }
   });
 };

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -293,5 +293,8 @@
   "reverse_explanation": "The reverse resolution is the procedure to translate an address into a name. It helps to access your address or your domain only knowing one of them after they are associated.",
   "reverse_success": "The reverse resolution has been set.",
   "not_set": "not set",
-  "domain": "Domain"
+  "domain": "Domain",
+  "register_subdomain": "The subdomain has been created.",
+  "update_subdomain": "The subdomain's address has been updated.",
+  "remove_subdomain": "The subdomain has been removed."
 }


### PR DESCRIPTION
Fixes bug where a subdomain would still persist if the delete action was interrupted by a browser refresh or closing. 

It also adds broswerNotifications that were missing in the original PR.

Closes #235 