### PR TITLE
Address input checksum

### DIFF
--- a/src/app/components/AddressInputComponent.js
+++ b/src/app/components/AddressInputComponent.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import propTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
+import { toChecksumAddress } from 'rskjs-util';
 
 import { validateAddress } from '../validations';
 import { ChecksumErrorContainer } from '../containers';
@@ -110,7 +111,7 @@ const AddressInputComponent = ({
           {strings.value_prefix
             && <span className="value-prefix">{`${strings.value_prefix}: `}</span>
           }
-          {valueDisplay || value}
+          {validation ? toChecksumAddress(value, validationChainId) : value}
         </div>
         <div className={`${allowDelete ? 'col-md-2' : 'col-md-1'} options`}>
           <button

--- a/src/app/components/AddressInputComponent.js
+++ b/src/app/components/AddressInputComponent.js
@@ -19,7 +19,6 @@ const AddressInputComponent = ({
   labelDisplay,
   labelIcon,
   value,
-  valueDisplay,
   isWaiting,
   isError,
   handleErrorClose,
@@ -254,7 +253,6 @@ AddressInputComponent.defaultProps = {
   handleErrorClose: () => {},
   handleSuccessClose: () => {},
   labelDisplay: null,
-  valueDisplay: null,
   labelIcon: null,
 };
 
@@ -274,7 +272,6 @@ AddressInputComponent.propTypes = {
   handleSubmit: propTypes.func.isRequired,
   handleDelete: propTypes.func,
   value: propTypes.string.isRequired,
-  valueDisplay: propTypes.string,
   validationChainId: propTypes.string,
   strings: propTypes.shape(),
 };

--- a/src/app/components/AddressInputComponent.test.js
+++ b/src/app/components/AddressInputComponent.test.js
@@ -12,7 +12,7 @@ describe('AddressInputComponent', () => {
     handleSuccessClose: jest.fn(),
     handleSubmit: jest.fn(),
     handleDelete: jest.fn(),
-    validate: false,
+    validation: false,
     strings: {
       cancel: 'cancel string',
       delete: 'delete string',
@@ -27,6 +27,15 @@ describe('AddressInputComponent', () => {
       success_message: 'success message text',
       value_prefix: 'value prefix',
       waiting: 'waiting text string',
+    },
+  };
+
+  const checksumInitialProps = {
+    ...initProps,
+    validation: true,
+    strings: {
+      ...initProps.strings,
+      value_prefix: '',
     },
   };
 
@@ -88,5 +97,43 @@ describe('AddressInputComponent', () => {
     const image = component.find('div.label').find('img');
     expect(image.props().src).toEqual('/assets/icons/icon_rsk.png');
     expect(image.props().alt).toEqual('rsk');
+  });
+
+  it('displays correct checksum for ethereum', () => {
+    const ethereumChecksum = '0xEe3D5f22Ea0FF393AeEf5Cf88a81E7d44979633B';
+
+    const localProps = {
+      ...checksumInitialProps,
+      value: '0xee3d5f22ea0ff393aeef5cf88a81e7d44979633b',
+    };
+
+    const component = shallow(<AddressInputComponent {...localProps} />);
+    expect(component.find('div.value').text()).toBe(ethereumChecksum);
+  });
+
+  it('displays correct checksum for RSK testnet', () => {
+    const rskTestnetChecksum = '0xEE3D5f22Ea0Ff393aeeF5cf88a81E7D44979633B';
+
+    const localProps = {
+      ...checksumInitialProps,
+      value: '0xee3d5f22ea0ff393aeef5cf88a81e7d44979633b',
+      validationChainId: 31,
+    };
+
+    const component = shallow(<AddressInputComponent {...localProps} />);
+    expect(component.find('div.value').text()).toBe(rskTestnetChecksum);
+  });
+
+  it('displays correct checksum for RSK mainnet', () => {
+    const rskMainnetChecksum = '0x5215d879F378c902E6CC0CB9ace0240Ac7a863E7';
+
+    const localProps = {
+      ...checksumInitialProps,
+      value: '0x5215d879f378c902e6cc0cb9ace0240ac7a863e7',
+      validationChainId: 30,
+    };
+
+    const component = shallow(<AddressInputComponent {...localProps} />);
+    expect(component.find('div.value').text()).toBe(rskMainnetChecksum);
   });
 });

--- a/src/app/components/AddressInputComponent.test.js
+++ b/src/app/components/AddressInputComponent.test.js
@@ -117,7 +117,7 @@ describe('AddressInputComponent', () => {
     const localProps = {
       ...checksumInitialProps,
       value: '0xee3d5f22ea0ff393aeef5cf88a81e7d44979633b',
-      validationChainId: 31,
+      validationChainId: '31',
     };
 
     const component = shallow(<AddressInputComponent {...localProps} />);
@@ -130,7 +130,7 @@ describe('AddressInputComponent', () => {
     const localProps = {
       ...checksumInitialProps,
       value: '0x5215d879f378c902e6cc0cb9ace0240ac7a863e7',
-      validationChainId: 30,
+      validationChainId: '30',
     };
 
     const component = shallow(<AddressInputComponent {...localProps} />);

--- a/src/app/tabs/newAdmin/addresses/components/YourAddressesComponent.js
+++ b/src/app/tabs/newAdmin/addresses/components/YourAddressesComponent.js
@@ -2,7 +2,6 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { multilanguage } from 'redux-multilanguage';
 import { Row, Col } from 'react-bootstrap';
-import { toChecksumAddress } from 'rskjs-util';
 
 import { ChainAddressEditContainer } from '../containers';
 import networks from '../networks.json';
@@ -40,7 +39,6 @@ const YourAddressesComponent = ({ strings, chainAddresses, resolverName }) => (
               labelIcon={network.icon}
               networkId={chainId}
               value={address}
-              valueDisplay={isHex ? toChecksumAddress(address, networkChainId) : address}
               isError={isError}
               isEditing={isEditing}
               isWaiting={isWaiting}

--- a/src/app/tabs/newAdmin/domainInfo/containers/TransferAddressContainer.js
+++ b/src/app/tabs/newAdmin/domainInfo/containers/TransferAddressContainer.js
@@ -11,6 +11,8 @@ const mapStateToProps = (state, ownProps) => ({
   label: state.auth.name,
   currentAddress: state.auth.address,
   value: state.auth.address,
+  validate: true,
+  validationChainId: state.auth.network,
   strings: {
     ...ownProps.strings,
     error_message: state.newAdmin.domainInfo.errorMessage,

--- a/src/app/tabs/newAdmin/reverse/components/ReverseComponent.js
+++ b/src/app/tabs/newAdmin/reverse/components/ReverseComponent.js
@@ -1,14 +1,15 @@
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-
 import propTypes from 'prop-types';
 import { multilanguage } from 'redux-multilanguage';
+import { toChecksumAddress } from 'rskjs-util';
+
 import ReverseInputContainer from '../containers/ReverseInputContainer';
 import { getReverse } from '../operations';
 
 const ReverseComponent = ({
   reverseValue, address, strings, isRequesting, isWaiting, isError,
-  errorMessage, isSuccess, successTx,
+  errorMessage, isSuccess, successTx, chainId,
 }) => {
   const dispatch = useDispatch();
   useEffect(() => dispatch(getReverse(address)), []);
@@ -18,13 +19,12 @@ const ReverseComponent = ({
   }
 
   return (
-    <div>
+    <div className="reverse">
       <p>{strings.reverse_explanation}</p>
       <h2>{strings.set_reverse}</h2>
       <ReverseInputContainer
         value={reverseValue}
-        valueDisplay={reverseValue || strings.not_set}
-        label={address}
+        label={toChecksumAddress(address, chainId)}
         allowDelete={false}
         validate={false}
         isWaiting={isWaiting}
@@ -59,6 +59,7 @@ ReverseComponent.propTypes = {
     wait_transation_confirmed: propTypes.string.isRequired,
   }).isRequired,
   address: propTypes.string.isRequired,
+  chainId: propTypes.string.isRequired,
   reverseValue: propTypes.string.isRequired,
   isRequesting: propTypes.bool.isRequired,
   isError: propTypes.bool.isRequired,

--- a/src/app/tabs/newAdmin/reverse/containers/ReverseContainer.js
+++ b/src/app/tabs/newAdmin/reverse/containers/ReverseContainer.js
@@ -4,6 +4,7 @@ import { ReverseComponent } from '../components';
 const mapStateToProps = state => ({
   reverseValue: state.newAdmin.reverse.value,
   address: state.auth.address,
+  chainId: state.auth.network,
   isRequesting: state.newAdmin.reverse.isRequesting,
   isWaiting: state.newAdmin.reverse.isWaiting,
   isError: state.newAdmin.reverse.isError,

--- a/src/app/tabs/newAdmin/subdomains/components/SubdomainListComponent.js
+++ b/src/app/tabs/newAdmin/subdomains/components/SubdomainListComponent.js
@@ -29,7 +29,6 @@ const SubdomainListComponent = ({
               label={subdomain.name}
               labelDisplay={`${subdomain.name}.${domain}`}
               value={subdomain.owner}
-              valueDisplay={toChecksumAddress(subdomain.owner, chainId)}
               isError={subdomain.editError !== ''}
               isWaiting={subdomain.isWaiting}
               isSuccess={subdomain.isSuccess}

--- a/src/app/tabs/newAdmin/subdomains/components/SubdomainListComponent.js
+++ b/src/app/tabs/newAdmin/subdomains/components/SubdomainListComponent.js
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import propTypes from 'prop-types';
 import { multilanguage } from 'redux-multilanguage';
 import { useDispatch } from 'react-redux';
-import { toChecksumAddress } from 'rskjs-util';
 
 import { SubdomainViewContainer } from '../containers';
 import { getSubdomainListFromLocalStorage } from '../operations';
@@ -34,6 +33,8 @@ const SubdomainListComponent = ({
               isSuccess={subdomain.isSuccess}
               successTx={subdomain.confirmedTx}
               reset={subdomain.isSuccess}
+              validation
+              validationChainId={chainId}
               strings={{
                 value_prefix: strings.owner,
                 error_message: subdomain.editError,

--- a/src/assets/css/sass/admin/_index.scss
+++ b/src/assets/css/sass/admin/_index.scss
@@ -3,6 +3,7 @@
   @import 'domainInfo';
   @import 'subdomains';
   @import 'address';
+  @import 'reverse';
 
   margin-top: 75px;
   

--- a/src/assets/css/sass/admin/_reverse.scss
+++ b/src/assets/css/sass/admin/_reverse.scss
@@ -1,0 +1,10 @@
+.reverse {
+  .addressInput {
+    .label {
+      overflow: visible;
+    }
+    .value {
+      text-align: right;
+    }
+  }  
+}


### PR DESCRIPTION
updates:

- AddressInput Component shows correct checksum when input is RSK or ETH address
- Removes valueDisplay as relies on the existing validation and validationChainId parameters.
- Formats Reverse view page better to show entire label.

Steps to test: https://hackmd.io/DRRL5Yk1QiuZNauti_R5IQ?view


Closes #226