### PR TITLE
Autologin

### DIFF
--- a/src/app/auth/operations.js
+++ b/src/app/auth/operations.js
@@ -185,7 +185,9 @@ export const start = callback => (dispatch) => {
           accounts.length !== 0,
         ));
 
-        if (localStorage.getItem('name')) {
+        if (window.location.search.includes('autologin')) {
+          dispatch(authenticate(window.location.search.split('=')[1], accounts[0]));
+        } else if (localStorage.getItem('name')) {
           dispatch(authenticate(localStorage.getItem('name'), accounts[0], true));
         }
       })

--- a/src/app/tabs/newAdmin/components/AdminTabComponent.js
+++ b/src/app/tabs/newAdmin/components/AdminTabComponent.js
@@ -1,12 +1,10 @@
 import React, { useEffect } from 'react';
 import propTypes from 'prop-types';
 import { multilanguage } from 'redux-multilanguage';
-import { useDispatch } from 'react-redux';
 import { Row, Col } from 'react-bootstrap';
 import { Switch, Route } from 'react-router';
 
 import { AuthTabWrapper } from '../../../auth';
-import { start } from '../operations';
 import { ToggleContainer } from '../../../containers';
 import UserWaitingComponent from '../../../components/UserWaitingComponent';
 
@@ -27,14 +25,14 @@ const AdminComponent = ({
   domain,
   isRegistryOwner,
   enabling,
+  start,
 }) => {
   if (enabling) {
     return <UserWaitingComponent />;
   }
 
   if (domain) {
-    const dispatch = useDispatch();
-    useEffect(() => dispatch(start(domain)), [dispatch]);
+    useEffect(() => start(), []);
   }
 
   return (
@@ -89,6 +87,7 @@ AdminComponent.propTypes = {
   domain: propTypes.string,
   isRegistryOwner: propTypes.bool.isRequired,
   enabling: propTypes.bool.isRequired,
+  start: propTypes.func.isRequired,
 };
 
 export default multilanguage(AdminComponent);

--- a/src/app/tabs/newAdmin/containers/AdminTabContainer.js
+++ b/src/app/tabs/newAdmin/containers/AdminTabContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { AdminTabComponent } from '../components';
-import { toggleBasicAdvancedSwitch } from '../operations';
+import { toggleBasicAdvancedSwitch, start } from '../operations';
 
 const mapStateToProps = state => ({
   advancedView: state.newAdmin.view.advancedView,
@@ -11,9 +11,17 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   toggleAdvancedBasic: value => dispatch(toggleBasicAdvancedSwitch(value)),
+  start: domain => dispatch(start(domain)),
+});
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...ownProps,
+  ...stateProps,
+  start: () => dispatchProps.start(stateProps.domain),
 });
 
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
+  mergeProps,
 )(AdminTabComponent);


### PR DESCRIPTION
Append `?autologin=domain.rsk` to any page to autologin, it then redirects to the /newAdmin page if you are the owner.

- If you are not the owner, the login modal appears to let you know you aren't the owner.
- If you are logged in to a different domain via localStorage, this fires first and logs into the new domain,

It also moves a `dispatch()` function from a component to its container. Better flow 
