### PR TITLE
Mobile CSS for Landing page and Registration Process

### DIFF
--- a/src/app/components/HeaderComponent.js
+++ b/src/app/components/HeaderComponent.js
@@ -19,7 +19,7 @@ const HeaderComponent = (props) => {
   return (
     <Navbar
       expand="md"
-      className="navbar-expand-md navbar-dark fixed-top"
+      className="navbar-expand-md navbar-dark sticky-top"
     >
       <Container>
         <Link to="/" className="navbar-brand">

--- a/src/app/components/ScrollToTopComponent.js
+++ b/src/app/components/ScrollToTopComponent.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+// source https://reacttraining.com/react-router/web/guides/scroll-restoration
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/app/components/index.js
+++ b/src/app/components/index.js
@@ -17,3 +17,4 @@ export { default as AddressInputComponent } from './AddressInputComponent';
 export { default as UserErrorComponent } from './UserErrorComponent';
 export { default as UserSuccessComponent } from './UserSuccessComponent';
 export { default as UserWaitingComponent } from './UserWaitingComponent';
+export { default as ScrollToTopComponent } from './ScrollToTopComponent';

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { ConnectedRouter } from 'connected-react-router';
 import Routes from './routes';
 import { HeaderContainer, FooterContainer } from './containers';
+import { ScrollToTopComponent } from './components';
 import { AuthModal } from './auth';
 
 
@@ -9,6 +10,7 @@ import { AuthModal } from './auth';
 const App = ({ history }) => (
   <ConnectedRouter history={history}>
     <React.Fragment>
+      <ScrollToTopComponent />
       <HeaderContainer />
       <Routes />
       <AuthModal />

--- a/src/app/tabs/home/components/HomeComponent.js
+++ b/src/app/tabs/home/components/HomeComponent.js
@@ -66,8 +66,8 @@ const HomeComponent = ({ strings }) => (
             </p>
           </div>
         </Row>
-        <Row className="major-section">
-          <div className="col-md-2 offset-md-2">
+        <Row className="major-section cta">
+          <div className="col-md-3 col-lg-2 offset-lg-2">
             <a
               className="btn btn-outline-primary"
               href="https://developers.rsk.co/rif/rns"
@@ -78,7 +78,7 @@ const HomeComponent = ({ strings }) => (
               <span>{strings.read_documentation}</span>
             </a>
           </div>
-          <div className="col-md-2">
+          <div className="col-md-3 col-lg-2 ">
             <a
               className="btn btn-outline-primary"
               href="https://github.com/rnsdomains"
@@ -89,7 +89,7 @@ const HomeComponent = ({ strings }) => (
               <span>{strings.collaborate_github}</span>
             </a>
           </div>
-          <div className="col-md-2">
+          <div className="col-md-3 col-lg-2 ">
             <a
               className="btn btn-outline-primary"
               href="https://developers.rsk.co/rif/rns/integrate"
@@ -100,7 +100,7 @@ const HomeComponent = ({ strings }) => (
               <span>{strings.integrate_rns}</span>
             </a>
           </div>
-          <div className="col-md-2">
+          <div className="col-md-3 col-lg-2">
             <a
               className="btn btn-outline-primary"
               href="https://gitter.im/rsksmart/rif-name-service"

--- a/src/app/tabs/home/components/SearchBoxComponent.js
+++ b/src/app/tabs/home/components/SearchBoxComponent.js
@@ -37,7 +37,7 @@ const SearchBoxComponent = ({ handleClick, strings }) => {
   return (
     <>
       <Form onSubmit={handleSearchEnter} className="searchBox row">
-        <div className="col-md-7 offset-md-1 searchInput">
+        <div className="col-md-7 col-lg-7 offset-lg-1 searchInput">
           <input
             placeholder={strings.search_placeholder}
             value={search}
@@ -45,7 +45,7 @@ const SearchBoxComponent = ({ handleClick, strings }) => {
           />
           <span className="blue">.rsk</span>
         </div>
-        <div className="col-md-3">
+        <div className="col-md-5 col-lg-3">
           <Button
             onClick={handleSearchClick}
           >

--- a/src/app/tabs/home/components/__snapshots__/SearchBoxComponent.test.js.snap
+++ b/src/app/tabs/home/components/__snapshots__/SearchBoxComponent.test.js.snap
@@ -39,7 +39,7 @@ exports[`SearchBoxComponent renders and matches snapshot 1`] = `
           onSubmit={[Function]}
         >
           <div
-            className="col-md-7 offset-md-1 searchInput"
+            className="col-md-7 col-lg-7 offset-lg-1 searchInput"
           >
             <input
               onChange={[Function]}
@@ -53,7 +53,7 @@ exports[`SearchBoxComponent renders and matches snapshot 1`] = `
             </span>
           </div>
           <div
-            className="col-md-3"
+            className="col-md-5 col-lg-3"
           >
             <Button
               active={false}

--- a/src/app/tabs/registrar/components/AutoLoginComponent.js
+++ b/src/app/tabs/registrar/components/AutoLoginComponent.js
@@ -13,7 +13,7 @@ const AutoLoginComponent = ({
       address={successTx}
       message=""
     />
-    <Row className="major-section">
+    <Row className="major-section next-steps">
       <div className="col-md-4 offset-md-2 col-lg-3 offset-lg-3">
         <Button onClick={handleManageClick} block>
           {strings.admin_domain}

--- a/src/app/tabs/registrar/components/__snapshots__/AutoLoginComponent.test.js.snap
+++ b/src/app/tabs/registrar/components/__snapshots__/AutoLoginComponent.test.js.snap
@@ -99,11 +99,11 @@ exports[`AutoLoginComponent should matches snapshot 1`] = `
         </UserSuccessComponent>
       </Connect(UserSuccessComponent)>
       <ForwardRef
-        className="major-section"
+        className="major-section next-steps"
         noGutters={false}
       >
         <div
-          className="major-section row"
+          className="major-section next-steps row"
         >
           <div
             className="col-md-4 offset-md-2 col-lg-3 offset-lg-3"

--- a/src/assets/css/sass/_columns.scss
+++ b/src/assets/css/sass/_columns.scss
@@ -1,3 +1,9 @@
 div.page, .page.container {
   margin-top:50px;
 }
+
+@media (max-width: 767.98px) {
+  div.page, .page.container {
+    margin-top:0;
+  }
+}

--- a/src/assets/css/sass/_containers.scss
+++ b/src/assets/css/sass/_containers.scss
@@ -1,0 +1,7 @@
+// tablet
+@media (max-width: 1199px) {
+  .row .row {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+}

--- a/src/assets/css/sass/_footer.scss
+++ b/src/assets/css/sass/_footer.scss
@@ -48,3 +48,14 @@ footer::before {
   position: relative;
   top: 125px;
 }
+
+// mobile styles
+@media (max-width: 767.98px) {
+  footer {
+    margin-top: -75px;
+
+    .footer-top {
+      padding-top: 0 !important;
+    }
+  }
+}

--- a/src/assets/css/sass/_header.scss
+++ b/src/assets/css/sass/_header.scss
@@ -77,6 +77,10 @@
 
 // mobile styles
 @media (max-width: 767.98px) {
+  .navbar {
+    position: relative !important;
+  }
+
   .navbar-brand {
     margin-left: 10px;
   }

--- a/src/assets/css/sass/home/_index.scss
+++ b/src/assets/css/sass/home/_index.scss
@@ -57,8 +57,9 @@
       width: 100%
     }
 
-    .col-md-2 {
+    .cta div {
       text-align: center;
+      margin-bottom: 15px;
 
       a {
         display: block;
@@ -81,6 +82,13 @@
   }
 }
 
+// tablet size
+@media (max-width: 1199px) {
+  .home .developer .cta div a {
+    padding: 15px !important;
+  }
+}
+
 // mobile styles
 @media (max-width: 767.98px) {
   .home {
@@ -92,13 +100,33 @@
       margin-bottom: 10px;
     }
 
+    form.searchBox.row {
+      padding-top: 0 !important;
+    }
+
+    .results .searchResults {
+      padding-top: 15px;
+
+      h3 {
+        margin-left: 0;
+      }
+
+      .register.btn-primary {
+        width: 100%;
+      }
+    }
+
     .spacer {
-      background-image: none;
-      background-color: $blue;
-      height: 15px;
+      height: 50px
+    }
+
+    .imageWraper {
+      margin-bottom: 15px;
     }
 
     .white {
+      margin: 25px 0;
+
       .imageWraper {
         min-height: auto !important;
       }

--- a/src/assets/css/sass/registration/_registration-page.scss
+++ b/src/assets/css/sass/registration/_registration-page.scss
@@ -59,3 +59,33 @@
     }
   }
 }
+
+
+// tablet size
+@media (max-width: 1199px) {
+  .register {
+    .list-inline li {
+      min-width: auto !important;
+    }
+  }
+}
+
+// mobile styles
+@media (max-width: 767.98px) {
+  .register {
+    .list-inline {
+      margin-bottom: 15px;
+
+      li {
+        margin:0 0 5px 0 !important;
+        display: block;
+      }
+    }
+
+    .next-steps {
+      div {
+        margin-bottom: 10px;
+      }
+    }
+  }
+}

--- a/src/assets/css/theming.css
+++ b/src/assets/css/theming.css
@@ -10,7 +10,6 @@ body {
     color: #000000;
     font-weight: 300;
     font-size: 16px;
-    padding-top: 66px;
 }
 
 .row {


### PR DESCRIPTION
QOL updates for the Manager on Mobile and Tablet

### home page

- Updated width in search box and submit for tablets and mobile, then removed top padding on mobile
- Search box curved blue back in and more subtle
- Add spacing below images to match amount on top.
- Call to Action boxes better sizing on tablet and breaks on mobile
- Reduce footer empty space while keeping curve gray 
- Smaller padding in .white section to reduce empty space
- Tighten up search results box

### registration process

- Tighten spacing on steps section 
- reduce space above rental period time
- Step 2 was good on mobile and tablet
- Step 3, add space between login and register another button

### overall

- Reduce space on mobile between nav bar and content
- Use sticky-top for menu to allow menu on mobile to push content down when opened
- Remove stickiness on mobile
- Scroll to the top of the page on router change. Closes #173 (not css/layout related but was bothering me)
