### PR TITLE
Update transactionListener 

### DIFF
--- a/src/app/helpers/transactionListener.js
+++ b/src/app/helpers/transactionListener.js
@@ -1,6 +1,13 @@
 import { TRANSACTION_RECEIPT_FAILED } from '../types';
 
-const transactionListener = (tx, callback, failCallBack = () => {}) => (dispatch) => {
+/**
+ * transactionListenerlistens to transactions on the blockchain and returns when
+ * a response if given.
+ * @param {tx} tx The transaction to listen to
+ * @param {func} callback The function to call on success
+ * @param {func} failCallBack (Optional) The function to call on fail.
+ */
+const transactionListener = (tx, callback, failCallBack = () => {}) => {
   const checkInterval = setInterval(() => {
     window.ethereum.sendAsync({
       method: 'eth_getTransactionReceipt',
@@ -8,11 +15,8 @@ const transactionListener = (tx, callback, failCallBack = () => {}) => (dispatch
     }, (err, response) => {
       if (response.result) {
         clearInterval(checkInterval);
-
-        if (parseInt(response.result.status, 16) === 1) {
-          return dispatch(callback());
-        }
-        return failCallBack(TRANSACTION_RECEIPT_FAILED);
+        return (parseInt(response.result.status, 16) === 1)
+          ? callback() : failCallBack(TRANSACTION_RECEIPT_FAILED);
       }
       return false;
     });

--- a/src/app/tabs/newAdmin/addresses/operations.js
+++ b/src/app/tabs/newAdmin/addresses/operations.js
@@ -66,11 +66,11 @@ const setPublicAddress = (domain, address, isNew) => async (dispatch) => {
         return dispatch(errorSetChainAddress('RSK', error.message));
       }
 
-      const transactionConfirmed = () => () => {
-        dispatch(receiveSetChainAddress('0x80000089', 'RSK', address, result, isNew));
-      };
-
-      return dispatch(transactionListener(result, () => transactionConfirmed()));
+      return transactionListener(
+        result,
+        () => dispatch(receiveSetChainAddress('0x80000089', 'RSK', address, result, isNew)),
+        errorReason => dispatch(errorSetChainAddress('RSK', errorReason)),
+      );
     },
   );
 };
@@ -97,7 +97,7 @@ const setMultiChainAddress = (domain, chainId, address, isNew) => async (dispatc
         return dispatch(errorSetChainAddress(chainName, error.message));
       }
 
-      const transactionConfirmed = () => () => {
+      const transactionConfirmed = () => {
         dispatch(receiveSetChainAddress(
           chainId, getChainNameById(chainId), address, result, isNew,
         ));
@@ -111,7 +111,11 @@ const setMultiChainAddress = (domain, chainId, address, isNew) => async (dispatc
         }
       };
 
-      return dispatch(transactionListener(result, () => transactionConfirmed()));
+      return transactionListener(
+        result,
+        () => transactionConfirmed(),
+        errorReason => dispatch(errorSetChainAddress(chainName, errorReason)),
+      );
     },
   );
 };
@@ -164,7 +168,11 @@ const setDefinitiveAddress = (domain, chainId, address, isNew) => async (dispatc
         }
       };
 
-      return dispatch(transactionListener(result, () => transactionConfirmed));
+      return transactionListener(
+        result,
+        () => transactionConfirmed(),
+        errorReason => dispatch(errorSetChainAddress(chainName, errorReason)),
+      );
     });
 };
 

--- a/src/app/tabs/newAdmin/reverse/operations.js
+++ b/src/app/tabs/newAdmin/reverse/operations.js
@@ -61,12 +61,16 @@ export const setReverse = value => async (dispatch) => {
 
       dispatch(waitingSetReverseResolver());
 
-      const transactionConfirmed = () => () => {
+      const transactionConfirmed = () => {
         sendBrowserNotification('RSK Manager', 'reverse_success');
         dispatch(receieveSetReverseResolver(value, result));
       };
 
-      return dispatch(transactionListener(result, () => transactionConfirmed()));
+      return transactionListener(
+        result,
+        () => transactionConfirmed(),
+        errorReason => dispatch(errorSetReverseResolver(errorReason)),
+      );
     },
   );
 };

--- a/src/app/tabs/newAdmin/subdomains/operations.js
+++ b/src/app/tabs/newAdmin/subdomains/operations.js
@@ -55,14 +55,18 @@ const registerSubdomain = (parentDomain, subdomain, newOwner) => async (dispatch
 
       dispatch(waitingNewSubdomainConfirm());
 
-      const transactionConfirmed = () => () => {
+      const transactionConfirmed = () => {
         dispatch(addSubdomainToList(subdomain, newOwner));
         dispatch(receiveNewSubdomain(result));
         updateSubdomainToLocalStorage(parentDomain, subdomain, true);
         sendBrowserNotification(`${subdomain}.${parentDomain}`, 'register_subdomain');
       };
 
-      return dispatch(transactionListener(result, () => transactionConfirmed()));
+      return transactionListener(
+        result,
+        () => transactionConfirmed(),
+        errorReason => dispatch(errorNewSubdomain(errorReason)),
+      );
     });
 };
 
@@ -173,7 +177,7 @@ export const setSubdomainOwner = (
         return dispatch(errorSetSubdomainOwner(subdomain, error.message));
       }
 
-      const transactionConfirmed = () => () => {
+      const transactionConfirmed = () => {
         dispatch(receiveSetSubdomainOwner(result, subdomain, newAddress));
 
         if (newAddress === EMPTY_ADDRESS) {
@@ -185,6 +189,10 @@ export const setSubdomainOwner = (
         }
       };
 
-      return dispatch(transactionListener(result, () => transactionConfirmed()));
+      return transactionListener(
+        result,
+        () => transactionConfirmed(),
+        errorReason => dispatch(errorSetSubdomainOwner(subdomain, errorReason)),
+      );
     });
 };

--- a/src/app/tabs/registrar/operations.js
+++ b/src/app/tabs/registrar/operations.js
@@ -119,11 +119,12 @@ export const commit = (domain, duration, rifCost, setupAddr) => async (dispatch)
           };
 
           dispatch(receiveCommitRegistrar(hashCommit));
-          return dispatch(transactionListener(
+
+          return transactionListener(
             result,
             () => dispatch(commitTxMined()),
             errorReason => transactionFailed(errorReason),
-          ));
+          );
         });
       });
   });
@@ -244,7 +245,7 @@ export const revealCommit = domain => async (dispatch) => {
           registerHash: result,
         }));
 
-        const revealCallback = () => () => {
+        const revealCallback = () => {
           dispatch(receiveRevealCommit());
           dispatch(revealTxMined(result));
           sendBrowserNotification(`${domain}.rsk`, 'notifications_registrar_revealed');
@@ -252,11 +253,11 @@ export const revealCommit = domain => async (dispatch) => {
           localStorage.removeItem(`${domain}-options`);
         };
 
-        return resolve(dispatch(transactionListener(
+        return resolve(transactionListener(
           result,
           () => revealCallback(),
           errorReason => dispatch(errorRevealCommit(errorReason)),
-        )));
+        ));
       });
   });
 };


### PR DESCRIPTION
This does 2 things.

1) All transactions that use the listener now also send `failCallBack` function that specifies the error to be sent if the transaction runs out of gas.

2) It removes the old `dispatch(callback())` structure as calling dispatch is not needed. Every single instance of the listener already had access to dispatch. This removes the need for `transactionConfirmed = () => () => {`.

Here is the current list of transactions that have been tested: https://hackmd.io/4JPaKZMeSju0IWMob8fpQw

### why draft? 

This is missing the contentHash and ContractABI as they are in PR #313. If that gets merged first, then I'll update this one.

#317 also uses the old version of the transactionListener. My hope is this one is merged before that one and will fix it in that PR. 
