### PR TITLE
Fix issue with supportedInterfaces not returning Public or Definitive addresses

### DIFF
--- a/src/app/tabs/newAdmin/resolver/operations.js
+++ b/src/app/tabs/newAdmin/resolver/operations.js
@@ -28,7 +28,7 @@ import { sendBrowserNotification } from '../../../browerNotifications/operations
 import {
   MULTICHAIN_RESOLVER, PUBLIC_RESOLVER, STRING_RESOLVER, UNKNOWN_RESOLVER,
   CONTENT_BYTES, CONTENT_BYTES_BLANK, DEFINITIVE_RESOLVER, CONTENT_HASH,
-  MULTICHAIN, MULTICOIN, CONTRACT_ABI,
+  MULTICHAIN, MULTICOIN, CONTRACT_ABI, ADDR,
 } from './types';
 
 import { resolverAbi, abstractResolverAbi } from './abis.json';
@@ -173,12 +173,13 @@ export const supportedInterfaces = (resolverAddress, domain) => (dispatch) => {
             case CONTENT_HASH:
               return dispatch(getContentHash(domain));
             case MULTICHAIN:
+            case MULTICOIN:
+            case ADDR:
               return dispatch(getAllChainAddresses(
                 domain, getResolverNameByAddress(resolverAddress),
               ));
             case CONTRACT_ABI:
               return (dispatch(getContractAbi(resolverAddress, domain)));
-            case MULTICOIN:
             default:
           }
         }

--- a/src/app/tabs/newAdmin/resolver/operations.js
+++ b/src/app/tabs/newAdmin/resolver/operations.js
@@ -450,7 +450,7 @@ export const setDomainResolverAndMigrate = (
     // valid address to be added to the multiCallMethods array:
     return multiCallMethods.push(
       definitiveResolver.methods['setAddr(bytes32,uint256,bytes)'](
-        hash, item[1].chainId, decodedAddress,
+        hash, getIndexById(item[1].chainId), decodedAddress,
       ).encodeABI(),
     );
   });

--- a/src/app/tabs/newAdmin/resolver/supportedInterfaces.json
+++ b/src/app/tabs/newAdmin/resolver/supportedInterfaces.json
@@ -35,6 +35,11 @@
       "interfaceId": "0xf1cb7e06",
       "type": "",
       "notes": "definitive resolver addr method"
+    },
+    {
+      "name": "ADDR",
+      "interfaceId": "0x3b3b57de",
+      "notes": "public resolver interfaceId for ADDR"
     }
   ]
 }

--- a/src/app/tabs/newAdmin/resolver/types.js
+++ b/src/app/tabs/newAdmin/resolver/types.js
@@ -37,3 +37,4 @@ export const CONTENT_HASH = 'CONTENT_HASH';
 export const MULTICHAIN = 'MULTICHAIN';
 export const MULTICOIN = 'MULTICOIN';
 export const CONTRACT_ABI = 'CONTRACT_ABI';
+export const ADDR = 'ADDR';


### PR DESCRIPTION
- Public: Add the ADDR interface
- Both: Have MULTICOIN, MULTICHAIN, and ADDR call the getAllChainAddresses function which uses switch between the resolvers