### PR TITLE
Transaction listeners and Failed Blockchain Response

### DIFF
--- a/src/app/helpers/transactionListener.js
+++ b/src/app/helpers/transactionListener.js
@@ -1,6 +1,16 @@
 import { TRANSACTION_RECEIPT_FAILED } from '../types';
 
-const transactionListener = (tx, callback, failCallBack = () => {}) => (dispatch) => {
+/**
+ * Transaction Listener
+ * @param {reciept} tx The TX to listen to on the blockchain
+ * @param {function} callback A function to be called on a Successful TX
+ * @param {array} successCallbackParams Parameters to be sent with successful callback
+ * @param {function} failCallback A function to be called on fail
+ * @param {array} failCallbackParams Parameters to be set with failed callback
+ */
+const transactionListener = (
+  tx, callback, successCallbackParams, failCallback, failCallbackParams,
+) => (dispatch) => {
   const checkInterval = setInterval(() => {
     window.ethereum.sendAsync({
       method: 'eth_getTransactionReceipt',
@@ -9,10 +19,11 @@ const transactionListener = (tx, callback, failCallBack = () => {}) => (dispatch
       if (response.result) {
         clearInterval(checkInterval);
 
-        if (parseInt(response.result.status, 16) === 1) {
-          return dispatch(callback());
-        }
-        return failCallBack(TRANSACTION_RECEIPT_FAILED);
+        return (parseInt(response.result.status, 16) === 1)
+          ? dispatch(callback({ ...successCallbackParams, resultTx: tx }))
+          : dispatch(failCallback({
+            ...failCallbackParams, errorReason: TRANSACTION_RECEIPT_FAILED,
+          }));
       }
       return false;
     });

--- a/src/app/tabs/newAdmin/reverse/operations.js
+++ b/src/app/tabs/newAdmin/reverse/operations.js
@@ -61,12 +61,19 @@ export const setReverse = value => async (dispatch) => {
 
       dispatch(waitingSetReverseResolver());
 
-      const transactionConfirmed = () => () => {
+      const transactionConfirmed = listenerParams => (listenerDispatch) => {
         sendBrowserNotification('RSK Manager', 'reverse_success');
-        dispatch(receieveSetReverseResolver(value, result));
+        listenerDispatch(receieveSetReverseResolver(listenerParams.value, listenerParams.resultTx));
       };
 
-      return dispatch(transactionListener(result, () => transactionConfirmed()));
+      return dispatch(transactionListener(
+        result,
+        transactionConfirmed,
+        { value },
+        listenerParams => listenerDispatch => listenerDispatch(
+          errorSetReverseResolver(listenerParams.errorReason),
+        ),
+      ));
     },
   );
 };


### PR DESCRIPTION
Fixes issue with `() => () =>` where the first is the parameters and the second is dispatch. All transactionListner will return dispatch(callback()) or dispatch(failedCallback()) depending on reason.

All listeners will now read the status from the blockchain and will execute `callback()` or `failedCallback` accordingly. 