### PR TITLE
Expired domains

### DIFF
--- a/src/app/tabs/newAdmin/components/AdminTabComponent.js
+++ b/src/app/tabs/newAdmin/components/AdminTabComponent.js
@@ -9,7 +9,7 @@ import { ToggleContainer } from '../../../containers';
 import UserWaitingComponent from '../../../components/UserWaitingComponent';
 
 import {
-  LeftNavContainer, ReclaimContainer,
+  LeftNavContainer, ReclaimContainer, ExpiredDomainContainer,
 } from '../containers';
 
 import { DomainInfoContainer } from '../domainInfo/containers';
@@ -26,6 +26,7 @@ const AdminComponent = ({
   isRegistryOwner,
   enabling,
   start,
+  isExpired,
 }) => {
   if (enabling) {
     return <UserWaitingComponent />;
@@ -33,6 +34,10 @@ const AdminComponent = ({
 
   if (domain) {
     useEffect(() => start(), []);
+  }
+
+  if (isExpired) {
+    return <ExpiredDomainContainer />;
   }
 
   return (
@@ -74,6 +79,7 @@ const AdminComponent = ({
 
 AdminComponent.defaultProps = {
   domain: '',
+  isExpired: false,
 };
 
 AdminComponent.propTypes = {
@@ -88,6 +94,7 @@ AdminComponent.propTypes = {
   isRegistryOwner: propTypes.bool.isRequired,
   enabling: propTypes.bool.isRequired,
   start: propTypes.func.isRequired,
+  isExpired: propTypes.bool,
 };
 
 export default multilanguage(AdminComponent);

--- a/src/app/tabs/newAdmin/components/ExpiredDomainComponent.js
+++ b/src/app/tabs/newAdmin/components/ExpiredDomainComponent.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { multilanguage } from 'redux-multilanguage'
+import propTypes from 'prop-types';
+
+import {
+  Row, Col, Container, Button,
+} from 'react-bootstrap';
+
+const ExpiredDomainComponent = ({ strings, handleClick }) => (
+  <Container className="page">
+    <Row className="domainInfo">
+      <Col md={12} style={{ textAlign: 'center' }}>
+        <h1 className="sub-heading">{strings.domain_expired}</h1>
+        <Button onClick={handleClick}>
+          {strings.search_for_domain}
+        </Button>
+      </Col>
+    </Row>
+  </Container>
+);
+
+ExpiredDomainComponent.propTypes = {
+  strings: propTypes.shape({
+    domain_expired: propTypes.string.isRequired,
+    search_for_domain: propTypes.string.isRequired,
+  }).isRequired,
+  handleClick: propTypes.func.isRequired,
+};
+
+export default multilanguage(ExpiredDomainComponent);

--- a/src/app/tabs/newAdmin/components/ExpiredDomainComponent.js
+++ b/src/app/tabs/newAdmin/components/ExpiredDomainComponent.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { multilanguage } from 'redux-multilanguage'
+import { multilanguage } from 'redux-multilanguage';
 import propTypes from 'prop-types';
 
 import {

--- a/src/app/tabs/newAdmin/components/LetftNavComponent.js
+++ b/src/app/tabs/newAdmin/components/LetftNavComponent.js
@@ -44,24 +44,24 @@ const LeftNavComponent = (props) => {
           </li>
           {advancedView
             && (
-            <>
-              <li>
-                <Link
-                  to="/newAdmin/resolver"
-                  className={location === '/newAdmin/resolver' ? 'active' : ''}
-                >
-                  {strings.resolver}
-                </Link>
-              </li>
-              <li>
-                <Link
-                  to="/newAdmin/reverse"
-                  className={location === '/newAdmin/reverse' ? 'active' : ''}
-                >
+              <>
+                <li>
+                  <Link
+                    to="/newAdmin/resolver"
+                    className={location === '/newAdmin/resolver' ? 'active' : ''}
+                  >
+                    {strings.resolver}
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    to="/newAdmin/reverse"
+                    className={location === '/newAdmin/reverse' ? 'active' : ''}
+                  >
                   Reverse
-                </Link>
-              </li>
-            </>
+                  </Link>
+                </li>
+              </>
             )
           }
         </ul>

--- a/src/app/tabs/newAdmin/components/ReclaimComponent.js
+++ b/src/app/tabs/newAdmin/components/ReclaimComponent.js
@@ -12,24 +12,24 @@ const ReclaimComponent = ({
   <div className="reclaim major-section">
 
     {(isDomainInfo && !isSettingRegistryOwner) && (
-    <>
-      <h2>{strings.set_controller}</h2>
-      <p>{strings.set_controller_explanation}</p>
-      <Row className="addressInput">
-        <div className="view row">
-          <Col md={3} className="label">
-            {domain}
-          </Col>
-          <Col md={9} className="value">
-            <span className="value-prefix">
-              {`${strings.controller}: `}
-            </span>
-            {registryOwner}
-          </Col>
-        </div>
-      </Row>
-      <br />
-    </>
+      <>
+        <h2>{strings.set_controller}</h2>
+        <p>{strings.set_controller_explanation}</p>
+        <Row className="addressInput">
+          <div className="view row">
+            <Col md={3} className="label">
+              {domain}
+            </Col>
+            <Col md={9} className="value">
+              <span className="value-prefix">
+                {`${strings.controller}: `}
+              </span>
+              {registryOwner}
+            </Col>
+          </div>
+        </Row>
+        <br />
+      </>
     )}
     <Row>
       <Col>

--- a/src/app/tabs/newAdmin/components/index.js
+++ b/src/app/tabs/newAdmin/components/index.js
@@ -1,3 +1,4 @@
 export { default as AdminTabComponent } from './AdminTabComponent';
 export { default as LeftNavComponent } from './LetftNavComponent';
 export { default as ReclaimComponent } from './ReclaimComponent';
+export { default as ExpiredDomainComponent } from './ExpiredDomainComponent';

--- a/src/app/tabs/newAdmin/containers/AdminTabContainer.js
+++ b/src/app/tabs/newAdmin/containers/AdminTabContainer.js
@@ -7,6 +7,7 @@ const mapStateToProps = state => ({
   isRegistryOwner: state.newAdmin.view.isRegistryOwner,
   domain: state.auth.name,
   enabling: state.auth.enabling,
+  isExpired: (state.newAdmin.domainInfo.expires <= 0),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/app/tabs/newAdmin/containers/ExpiredDomainContainer.js
+++ b/src/app/tabs/newAdmin/containers/ExpiredDomainContainer.js
@@ -1,0 +1,29 @@
+import { connect } from 'react-redux';
+import { push } from 'connected-react-router';
+import { ExpiredDomainComponent } from '../components';
+import getDomainState from '../../search/operations';
+
+const mapStateToProps = state => ({
+  domain: state.auth.name,
+  expires: state.newAdmin.domainInfo.expires,
+});
+
+const mapDispatchToProps = dispatch => ({
+  handleClick: (domain) => {
+    dispatch(getDomainState(domain.replace('.rsk', '')));
+    dispatch(push('/'));
+  },
+});
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...ownProps,
+  ...stateProps,
+  ...dispatchProps,
+  handleClick: () => dispatchProps.handleClick(stateProps.domain),
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps,
+)(ExpiredDomainComponent);

--- a/src/app/tabs/newAdmin/containers/index.js
+++ b/src/app/tabs/newAdmin/containers/index.js
@@ -1,3 +1,4 @@
 export { default as AdminTabContainer } from './AdminTabContainer';
 export { default as LeftNavContainer } from './LeftNavContainer';
 export { default as ReclaimContainer } from './ReclaimContainer';
+export { default as ExpiredDomainContainer } from './ExpiredDomainContainer';

--- a/src/app/tabs/newAdmin/domainInfo/abis.json
+++ b/src/app/tabs/newAdmin/domainInfo/abis.json
@@ -169,5 +169,22 @@
       "stateMutability": "nonpayable",
       "type": "function"
     }
+  ],
+  "deedAbi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "expirationDate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
   ]
 }

--- a/src/app/tabs/newAdmin/domainInfo/components/DomainInfoComponent.js
+++ b/src/app/tabs/newAdmin/domainInfo/components/DomainInfoComponent.js
@@ -24,6 +24,7 @@ const DomainInfoComponent = (props) => {
     checkingRegistryOwner,
     checkingOwnership,
     isRegistryOwner,
+    isFifsMigrated,
   } = props;
 
   if (isTransferSuccess) {
@@ -54,7 +55,7 @@ const DomainInfoComponent = (props) => {
         )}
       </Row>
       <RenewDomainContainer />
-      {(isTokenOwner && !isSubdomain)
+      {(isTokenOwner && !isSubdomain && isFifsMigrated)
       && (
       <Row className="break-above">
         <Col>
@@ -99,6 +100,7 @@ DomainInfoComponent.propTypes = {
   checkingRegistryOwner: propTypes.bool.isRequired,
   checkingOwnership: propTypes.bool.isRequired,
   isRegistryOwner: propTypes.bool.isRequired,
+  isFifsMigrated: propTypes.bool.isRequired,
 };
 
 export default multilanguage(DomainInfoComponent);

--- a/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.js
+++ b/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.js
@@ -16,9 +16,8 @@ const RenewButtonComponent = (props) => {
 
   return (
     <p>
-      {strings.expires_on}
-      {' '}
-      {formatDate(dayMath(expires))}
+      {disable ? strings.domain_expired : `${strings.expires_on} ${formatDate(dayMath(expires))}`}
+
       <Button onClick={handleClick} className={isRenewOpen ? 'active' : ''} disabled={disable}>
         {strings.renew}
       </Button>
@@ -33,6 +32,7 @@ RenewButtonComponent.propTypes = {
   strings: propTypes.shape({
     expires_on: propTypes.string.isRequired,
     renew: propTypes.string.isRequired,
+    domain_expired: propTypes.string.isRequired,
   }).isRequired,
   handleClick: propTypes.func.isRequired,
   isFifsMigrated: propTypes.bool.isRequired,

--- a/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.js
+++ b/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.js
@@ -9,10 +9,10 @@ import { dayMath, formatDate } from '../../helpers';
 const RenewButtonComponent = (props) => {
   const {
     expires, handleClick, checkingExpirationTime, isRenewOpen,
-    strings,
+    strings, isFifsMigrated,
   } = props;
 
-  if (checkingExpirationTime || expires === 0) {
+  if (checkingExpirationTime || expires <= 0 || !isFifsMigrated) {
     return (<></>);
   }
 
@@ -37,6 +37,7 @@ RenewButtonComponent.propTypes = {
     renew: propTypes.string.isRequired,
   }).isRequired,
   handleClick: propTypes.func.isRequired,
+  isFifsMigrated: propTypes.bool.isRequired,
 };
 
 export default multilanguage(RenewButtonComponent);

--- a/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.js
+++ b/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.js
@@ -12,7 +12,7 @@ const RenewButtonComponent = (props) => {
     strings, isFifsMigrated,
   } = props;
 
-  const disable = (checkingExpirationTime || expires <= 0 || !isFifsMigrated)
+  const disable = (checkingExpirationTime || expires <= 0 || !isFifsMigrated);
 
   return (
     <p>

--- a/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.js
+++ b/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.js
@@ -12,16 +12,14 @@ const RenewButtonComponent = (props) => {
     strings, isFifsMigrated,
   } = props;
 
-  if (checkingExpirationTime || expires <= 0 || !isFifsMigrated) {
-    return (<></>);
-  }
+  const disable = (checkingExpirationTime || expires <= 0 || !isFifsMigrated)
 
   return (
     <p>
       {strings.expires_on}
       {' '}
       {formatDate(dayMath(expires))}
-      <Button onClick={handleClick} className={isRenewOpen ? 'active' : ''}>
+      <Button onClick={handleClick} className={isRenewOpen ? 'active' : ''} disabled={disable}>
         {strings.renew}
       </Button>
     </p>

--- a/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.test.js
+++ b/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.test.js
@@ -55,6 +55,6 @@ describe('RenewButtonComponent', () => {
         <RenewButtonComponent {...localProps} />
       </Provider>,
     );
-    expect(component.html()).toBe('');
+    expect(component.find('button').prop('disabled')).toBeTruthy;
   });
 });

--- a/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.test.js
+++ b/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.test.js
@@ -9,6 +9,7 @@ import RenewButtonComponent from './RenewButtonComponent';
 const store = mockStore({
   expires_on: en.expires_on,
   renew: en.renew,
+  domain_expired: en.domain_expired,
 });
 
 const handleClick = jest.fn();
@@ -55,6 +56,6 @@ describe('RenewButtonComponent', () => {
         <RenewButtonComponent {...localProps} />
       </Provider>,
     );
-    expect(component.find('button').prop('disabled')).toBeTruthy;
+    expect(component.find('button').prop('disabled')).toBeTruthy();
   });
 });

--- a/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.test.js
+++ b/src/app/tabs/newAdmin/domainInfo/components/RenewButtonComponent.test.js
@@ -19,6 +19,7 @@ const initProps = {
   handleClick,
   checkingExpirationTime: false,
   isRenewOpen: false,
+  isFifsMigrated: true,
 };
 
 describe('RenewButtonComponent', () => {

--- a/src/app/tabs/newAdmin/domainInfo/containers/DomainInfoContainer.js
+++ b/src/app/tabs/newAdmin/domainInfo/containers/DomainInfoContainer.js
@@ -9,6 +9,7 @@ const mapStateToProps = state => ({
   isTransferSuccess: state.newAdmin.domainInfo.isTransferSuccess,
   checkingRegistryOwner: state.newAdmin.view.checkingRegistryOwner,
   checkingOwnership: state.newAdmin.view.checkingRegistryOwner,
+  isFifsMigrated: state.newAdmin.view.isFifsMigrated,
 });
 
 export default connect(

--- a/src/app/tabs/newAdmin/domainInfo/containers/RenewButtonContainer.js
+++ b/src/app/tabs/newAdmin/domainInfo/containers/RenewButtonContainer.js
@@ -6,6 +6,7 @@ const mapStateToProps = state => ({
   expires: state.newAdmin.domainInfo.expires,
   isRenewOpen: state.newAdmin.domainInfo.isRenewOpen,
   checkingExpirationTime: state.newAdmin.domainInfo.checkingExpirationTime,
+  isFifsMigrated: state.newAdmin.view.isFifsMigrated,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/app/tabs/newAdmin/domainInfo/operations.js
+++ b/src/app/tabs/newAdmin/domainInfo/operations.js
@@ -59,7 +59,7 @@ export const checkIfSubdomainAndGetExpirationRemaining = name => (dispatch) => {
       // the difference is in seconds, so it is divided by the amount of seconds per day
       const getRemainingDays = exp => Math.floor((exp - currentBlock.timestamp) / (60 * 60 * 24));
 
-      const remainingDays = getRemainingDays(expirationTime)
+      const remainingDays = getRemainingDays(expirationTime);
 
       if (remainingDays > 0) {
         return dispatch(receiveDomainExpirationTime(remainingDays));
@@ -72,15 +72,15 @@ export const checkIfSubdomainAndGetExpirationRemaining = name => (dispatch) => {
         tokenRegistrarAddress,
       );
 
-      auctionRegistrar.methods.entries(hash).call()
-        .then(entries => {
-          const deed = new web3.eth.Contract(deedAbi, entries[1])
-          return deed.methods.expirationDate().call()
+      return auctionRegistrar.methods.entries(hash).call()
+        .then((entries) => {
+          const deed = new web3.eth.Contract(deedAbi, entries[1]);
+          return deed.methods.expirationDate().call();
         })
-        .then(deedExpirationTime => {
-          const remaining = getRemainingDays(deedExpirationTime)
-          dispatch(receiveDomainExpirationTime(remaining))
-        })
+        .then((deedExpirationTime) => {
+          const remaining = getRemainingDays(deedExpirationTime);
+          dispatch(receiveDomainExpirationTime(remaining));
+        });
     });
   });
 };

--- a/src/app/tabs/newAdmin/domainInfo/operations.js
+++ b/src/app/tabs/newAdmin/domainInfo/operations.js
@@ -10,7 +10,7 @@ import {
   registrar as tokenRegistrarAddress,
 } from '../../../adapters/configAdapter';
 import {
-  rskOwnerAbi, rifAbi, tokenRegistrarAbi,
+  rskOwnerAbi, rifAbi, tokenRegistrarAbi, deedAbi,
 } from './abis.json';
 import { gasPrice as defaultGasPrice } from '../../../adapters/gasPriceAdapter';
 import { getOptions } from '../../../adapters/RNSLibAdapter';
@@ -56,12 +56,31 @@ export const checkIfSubdomainAndGetExpirationRemaining = name => (dispatch) => {
         return dispatch(errorDomainExpirationTime());
       }
 
-      const diff = expirationTime - currentBlock.timestamp;
-
       // the difference is in seconds, so it is divided by the amount of seconds per day
-      const remainingDays = Math.floor(diff / (60 * 60 * 24));
+      const getRemainingDays = exp => Math.floor((exp - currentBlock.timestamp) / (60 * 60 * 24));
 
-      return dispatch(receiveDomainExpirationTime(remainingDays));
+      const remainingDays = getRemainingDays(expirationTime)
+
+      if (remainingDays > 0) {
+        return dispatch(receiveDomainExpirationTime(remainingDays));
+      }
+
+      // this means he logged in but the expiration time was not found
+      // in the rsk owner => it is in the auction regisrar
+      const auctionRegistrar = new web3.eth.Contract(
+        tokenRegistrarAbi,
+        tokenRegistrarAddress,
+      );
+
+      auctionRegistrar.methods.entries(hash).call()
+        .then(entries => {
+          const deed = new web3.eth.Contract(deedAbi, entries[1])
+          return deed.methods.expirationDate().call()
+        })
+        .then(deedExpirationTime => {
+          const remaining = getRemainingDays(deedExpirationTime)
+          dispatch(receiveDomainExpirationTime(remaining))
+        })
     });
   });
 };

--- a/src/app/tabs/newAdmin/resolver/components/ViewContractAbiComponent.js
+++ b/src/app/tabs/newAdmin/resolver/components/ViewContractAbiComponent.js
@@ -78,17 +78,17 @@ const ViewContractAbiComponent = ({
         {!isEditing && (
         <div className="col-md-9">
           {prettyJson && (
-          <>
-            <p>Contract ABI Value</p>
-            <pre className="contractAbi">{prettyJson}</pre>
-          </>
+            <>
+              <p>Contract ABI Value</p>
+              <pre className="contractAbi">{prettyJson}</pre>
+            </>
           )}
 
           {prettyUri && (
-          <>
-            <p>URI</p>
-            <div className="uri">{prettyUri}</div>
-          </>
+            <>
+              <p>URI</p>
+              <div className="uri">{prettyUri}</div>
+            </>
           )}
           <p>Stored as:</p>
           <ul>

--- a/src/app/tabs/registrar/components/RegistrarComponent.js
+++ b/src/app/tabs/registrar/components/RegistrarComponent.js
@@ -145,24 +145,24 @@ class RegistrarComponent extends Component {
           }
 
           {waiting && (
-          <>
-            <LoadingContainer />
-            <TextRotationComponent
-              messages={shuffle(keyMessages)}
-              language={language}
-              heading={strings.did_you_know}
-              timer={6000}
-            />
-            <p style={{ marginTop: '50px' }}>
-              <a
-                href="https://hackmd.io/@ilanolkies/rns-user-guide"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {strings.download_guide}
-              </a>
-            </p>
-          </>
+            <>
+              <LoadingContainer />
+              <TextRotationComponent
+                messages={shuffle(keyMessages)}
+                language={language}
+                heading={strings.did_you_know}
+                timer={6000}
+              />
+              <p style={{ marginTop: '50px' }}>
+                <a
+                  href="https://hackmd.io/@ilanolkies/rns-user-guide"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {strings.download_guide}
+                </a>
+              </p>
+            </>
           )}
 
           {(canReveal && !revealConfirmed)

--- a/src/config/contracts.local.json
+++ b/src/config/contracts.local.json
@@ -10,5 +10,6 @@
   "fifsAddrRegistrar": "",
   "rskOwner": "",
   "renewer": "",
-  "stringResolver": ""
+  "stringResolver": "",
+  "definitiveResolver": ""
 }

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -399,5 +399,7 @@
   "content_hash": "Content Hash",
   "contract_abi": "Contract ABI",
   "contract_abi_set": "Contract ABI has been set.",
-  "contracts_not_set": "Contracts Not Set"
+  "contracts_not_set": "Contracts Not Set",
+  "domain_expired": "Your domain has expired",
+  "search_for_domain": "See if you can register it again"
 }

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -401,5 +401,5 @@
   "contract_abi_set": "Contract ABI has been set.",
   "contracts_not_set": "Contracts Not Set",
   "domain_expired": "Your domain has expired",
-  "search_for_domain": "See if you can register it again"
+  "search_for_domain": "Register it again"
 }

--- a/src/languages/es_uy.json
+++ b/src/languages/es_uy.json
@@ -399,5 +399,7 @@
   "transaction_receipt_failed": "La transacción falló. Contáctanos a través de Gitter para obtener ayuda.",
   "content_hash": "Contenido hash",
   "contract_abi": "Contrato ABI",
-  "contract_abi_set": "El contrato ABI ha sido configurado."
+  "contract_abi_set": "El contrato ABI ha sido configurado.",
+  "domain_expired": "Su dominio ha expirado",
+  "search_for_domain": "Regístralo nuevamente"
 }

--- a/src/languages/ja.json
+++ b/src/languages/ja.json
@@ -400,5 +400,7 @@
   "transaction_receipt_failed": "トランザクションが失敗しました。サポートは、Gitter経由で承っております。",
   "content_hash": "コンテンツハッシュ",
   "contract_abi": "コントラクトABI",
-  "contract_abi_set": "コントラクトABIが設定されました。"
+  "contract_abi_set": "コントラクトABIが設定されました。",
+  "domain_expired": "ドメインの有効期限が切れています",
+  "search_for_domain": "もう一度登録する"
 }

--- a/src/languages/ko.json
+++ b/src/languages/ko.json
@@ -400,5 +400,7 @@
   "transaction_receipt_failed": "거래 실패. Gitter를 통해 지원을 요청하시기 바랍니다.",
   "content_hash": "콘텐츠_해시",
   "contract_abi": "컨트랙트_ABI",
-  "contract_abi_set": "컨트랙트 ABI가 설정 완료되었습니다."
+  "contract_abi_set": "컨트랙트 ABI가 설정 완료되었습니다.",
+  "domain_expired": "도메인이 만료되었습니다",
+  "search_for_domain": "다시 등록하십시오"
 }

--- a/src/languages/pt_br.json
+++ b/src/languages/pt_br.json
@@ -400,5 +400,7 @@
   "transaction_receipt_failed": "Falha na transação. Entre em contato conosco via Gitter para obter suporte.",
   "content_hash": "Conteúdo Hash",
   "contract_abi": "Contrato ABI",
-  "contract_abi_set": "Contrato ABI foi definido."
+  "contract_abi_set": "Contrato ABI foi definido.",
+  "domain_expired": "Seu domínio expirou",
+  "search_for_domain": "Registre-o novamente"
 }

--- a/src/languages/ru.json
+++ b/src/languages/ru.json
@@ -400,5 +400,7 @@
   "transaction_receipt_failed": "Транзакция не удалась. Для получения поддержки свяжитесь с нами через Gitter.",
   "content_hash": "Хэш данных",
   "contract_abi": "ABI контракта",
-  "contract_abi_set": "ABI контракта установлен."
+  "contract_abi_set": "ABI контракта установлен.",
+  "domain_expired": "Срок действия вашего домена истек",
+  "search_for_domain": "Зарегистрируй еще раз"
 }

--- a/src/languages/zh_cn.json
+++ b/src/languages/zh_cn.json
@@ -400,5 +400,7 @@
   "transaction_receipt_failed": "交易失败。通过 Gitter 与我们联系以获得支持。",
   "content_hash": "内容散列",
   "contract_abi": "合约 ABI",
-  "contract_abi_set": "合约 ABI 已设置。"
+  "contract_abi_set": "合约 ABI 已设置。",
+  "domain_expired": "您的网域已过期",
+  "search_for_domain": "重新注册"
 }


### PR DESCRIPTION
This PR handles two situations. One of which I need help testing.

1) The domain is expired - Show a screen saying the domain is expired and suggest the user search for it again. Tested and works.

2) Don't show Renew or Transfer if the domain has not been migrated to FIFS. I tested this independently before implementing the domain expired and it worked. However, the rns-suite setup for the auction registrars is domains that are expired. So, when I log on to those, option 1 shows first.