### PR TITLE
Support IPNS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "rns-manager-react",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "dependencies": {
     "@ensdomains/address-encoder": "^0.1.8",
     "@githubprimer/octicons-react": "^8.5.0",
     "@rsksmart/rlogin": "^0.0.1-beta.3",
-    "@rsksmart/rns": "^1.8.2",
-    "@rsksmart/rns-suite": "^1.0.4",
+    "@rsksmart/rns": "^1.9.0",
+    "@rsksmart/rns-suite": "^1.1.0",
     "bootstrap": "^4.3.1",
     "cbor": "^5.0.2",
     "connected-react-router": "^6.3.1",

--- a/src/app/tabs/newAdmin/resolver/components/NewRecordComponent.js
+++ b/src/app/tabs/newAdmin/resolver/components/NewRecordComponent.js
@@ -9,6 +9,8 @@ import UserWaitingComponent from '../../../../components/UserWaitingComponent';
 import UserErrorComponent from '../../../../components/UserErrorComponent';
 import { CONTRACT_ABI, CONTENT_HASH } from '../types';
 
+export const contentHashPlaceholder = 'ipfs://..., ipns://..., bzz://..., onion://..., onion3://...';
+
 const NewRecordComponent = ({
   strings, content, handleSubmit, handleCloseMessage,
 }) => {
@@ -59,7 +61,7 @@ const NewRecordComponent = ({
             value={value}
             onChange={evt => setValue(evt.target.value)}
             disabled={activeOptions.isWaiting}
-            placeholder={selectedContent === CONTENT_HASH ? 'ipfs://..., ipns://..., bzz://..., onion://..., onion3://...' : 'bytes32'}
+            placeholder={selectedContent === CONTENT_HASH ? contentHashPlaceholder : 'bytes32'}
           />
         </div>
         <div className="col-md-2">

--- a/src/app/tabs/newAdmin/resolver/components/NewRecordComponent.js
+++ b/src/app/tabs/newAdmin/resolver/components/NewRecordComponent.js
@@ -59,7 +59,7 @@ const NewRecordComponent = ({
             value={value}
             onChange={evt => setValue(evt.target.value)}
             disabled={activeOptions.isWaiting}
-            placeholder={selectedContent === CONTENT_HASH ? '/ipfs/, ipfs://..., bzz://..., onion://..., onion3://...' : 'bytes32'}
+            placeholder={selectedContent === CONTENT_HASH ? 'ipfs://..., ipns://..., bzz://..., onion://..., onion3://...' : 'bytes32'}
           />
         </div>
         <div className="col-md-2">

--- a/src/app/tabs/newAdmin/resolver/components/ViewRecordsComponent.js
+++ b/src/app/tabs/newAdmin/resolver/components/ViewRecordsComponent.js
@@ -19,7 +19,7 @@ const ResolverComponent = ({ strings, start, content }) => {
       default:
         // eslint-disable-next-line no-case-declarations
         const placeholder = (item[0] === CONTENT_HASH)
-          ? '/ipfs/, ipfs://..., bzz://..., onion://..., onion3://...' : '';
+          ? 'ipfs://..., ipns://..., bzz://..., onion://..., onion3://...' : '';
 
         return (
           <EditContentContainer

--- a/src/app/tabs/newAdmin/resolver/components/ViewRecordsComponent.js
+++ b/src/app/tabs/newAdmin/resolver/components/ViewRecordsComponent.js
@@ -4,6 +4,7 @@ import { multilanguage } from 'redux-multilanguage';
 
 import { EditContentContainer, ViewContractAbiContainer } from '../containers';
 import { CONTRACT_ABI, CONTENT_HASH } from '../types';
+import { contentHashPlaceholder } from './NewRecordComponent';
 
 const ResolverComponent = ({ strings, start, content }) => {
   useEffect(() => start(), []);
@@ -17,10 +18,6 @@ const ResolverComponent = ({ strings, start, content }) => {
       case CONTRACT_ABI:
         return <ViewContractAbiContainer value={item[1].value} />;
       default:
-        // eslint-disable-next-line no-case-declarations
-        const placeholder = (item[0] === CONTENT_HASH)
-          ? 'ipfs://..., ipns://..., bzz://..., onion://..., onion3://...' : '';
-
         return (
           <EditContentContainer
             key={item[0]}
@@ -34,7 +31,7 @@ const ResolverComponent = ({ strings, start, content }) => {
               delete: strings.delete,
               delete_confirm_text: strings.delete_content_confirm,
               success_message: strings.content_updated,
-              edit_placeholder: placeholder,
+              edit_placeholder: (item[0] === CONTENT_HASH) ? contentHashPlaceholder : '',
             }}
           />
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,7 +1652,7 @@
     "@rsksmart/rns-registry" "^1.0.0"
     "@rsksmart/rns-resolver" "^2.0.0"
 
-"@rsksmart/rns-suite@^1.0.4":
+"@rsksmart/rns-suite@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rsksmart/rns-suite/-/rns-suite-1.1.0.tgz#dd190eb353ed75099a05d4188e941ee563ca5b53"
   integrity sha512-W0x9ZQ0WuRw4Cx5GYzmPyqvL+BdKhv3NDPiXUpOJ69FwF2ea6XXMKF7eFmnzFG4z5dE+wcEk2DEDB2J+aynTzQ==
@@ -1669,7 +1669,7 @@
     truffle "^5.1.17"
     web3 "^1.2.6"
 
-"@rsksmart/rns@^1.8.2":
+"@rsksmart/rns@^1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@rsksmart/rns/-/rns-1.9.0.tgz#62dafd031203ecfd894030382e5d6c29d58060eb"
   integrity sha512-DFMhuUexVIuzYeXvD3v6m1GMngZKgcVJdxpRUK8CalzHHQdPUq+N8cWDnzqpzagQJiiNagZXgJXzJLHyTvk9WA==


### PR DESCRIPTION
- Bump dependencies to support IPNS.
- Update placeholder text, add `ipns://` and remove `/ipfs` since it seems to only accept `ipfs://`

Continues from #341, I was unable to rebase that PR correctly. 