### PR TITLE
Remove check of resolver address from the notification's reducer

### DIFF
--- a/src/app/auth/operations.js
+++ b/src/app/auth/operations.js
@@ -8,7 +8,6 @@ import {
   registrar as auctionRegistrarAddress,
 } from '../adapters/configAdapter';
 import { rskNode } from '../adapters/nodeAdapter';
-import { checkResolver } from '../notifications';
 
 import {
   receiveHasWeb3Provider,
@@ -84,8 +83,6 @@ export const removeDomainToLocalStorage = (domain) => {
 };
 
 const successfulLogin = (name, noRedirect) => (dispatch) => {
-  dispatch(checkResolver(name));
-
   if (!noRedirect) {
     dispatch(push('/newAdmin'));
   }

--- a/src/app/notifications/index.js
+++ b/src/app/notifications/index.js
@@ -2,7 +2,7 @@ export { default } from './reducer';
 
 export { notificationTypes, txTypes } from './types';
 export { notifyError } from './actions';
-export { notifyTx, checkResolver } from './operations';
+export { notifyTx } from './operations';
 export {
   NotificationListContainer as Notifications,
   NotificationIconContainer as NotificationIcon,

--- a/src/app/notifications/operations.js
+++ b/src/app/notifications/operations.js
@@ -1,6 +1,5 @@
-import { hash as namehash } from 'eth-ens-namehash';
-import { addTxNotification, txMined, notifyMigrateResolver } from './actions';
-import { rns as rnsAddress, publicResolver } from '../adapters/configAdapter';
+import { addTxNotification, txMined } from './actions';
+
 
 export const notifyTx = (tx, message, params, callback) => (dispatch) => {
   dispatch(addTxNotification(tx, message, params));
@@ -19,30 +18,4 @@ export const notifyTx = (tx, message, params, callback) => (dispatch) => {
   }, 2000);
 };
 
-export const checkResolver = name => (dispatch) => {
-  const rns = window.web3 && window.web3.eth.contract([
-    {
-      constant: true,
-      inputs: [
-        { name: 'node', type: 'bytes32' },
-      ],
-      name: 'resolver',
-      outputs: [
-        { name: '', type: 'address' },
-      ],
-      payable: false,
-      stateMutability: 'view',
-      type: 'function',
-    },
-  ]).at(rnsAddress);
-
-  const node = namehash(name);
-
-  return new Promise((resolve) => {
-    rns.resolver(node, (error, result) => {
-      if (!error && result && result.toLowerCase() === publicResolver) {
-        resolve(dispatch(notifyMigrateResolver()));
-      }
-    });
-  });
-};
+export default notifyTx;

--- a/src/app/tabs/admin/operations.js
+++ b/src/app/tabs/admin/operations.js
@@ -29,7 +29,7 @@ import {
   rnsAbi, reverseAbi, nameResolverAbi, tokenRegistrarAbi, rskOwnerAbi,
 } from './abis.json';
 
-const web3 = new Web3(window.ethereum);
+const web3 = new Web3(window.rLogin);
 const registry = new web3.eth.Contract(
   rnsAbi, registryAddress, { gasPrice: defaultGasPrice },
 );

--- a/src/app/tabs/admin/operations.js
+++ b/src/app/tabs/admin/operations.js
@@ -22,7 +22,7 @@ import {
 } from '../../adapters/configAdapter';
 import { gasPrice as defaultGasPrice } from '../../adapters/gasPriceAdapter';
 import {
-  notifyTx, notifyError, txTypes, checkResolver,
+  notifyTx, notifyError, txTypes,
 } from '../../notifications';
 import { get, set } from '../../factories/operationFactory';
 import {
@@ -68,7 +68,6 @@ export const setDomainResolver = set(
   registry.methods.setResolver,
   name => (dispatch) => {
     dispatch(getDomainResolver(name));
-    dispatch(checkResolver(name));
   },
 );
 export const setDomainTtl = set(

--- a/src/app/tabs/multiChainResolver/operations.js
+++ b/src/app/tabs/multiChainResolver/operations.js
@@ -9,7 +9,7 @@ import { txTypes, notifyTx, notifyError } from '../../notifications';
 import { get, set } from '../../factories/operationFactory';
 import abi from './abi.json';
 
-const web3 = new Web3(window.ethereum);
+const web3 = new Web3(window.rLogin);
 const resolver = new web3.eth.Contract(abi, resolverAddress, { gasPrice: defaultGasPrice });
 
 export const getContent = get(

--- a/src/app/tabs/publicResolver/operations.js
+++ b/src/app/tabs/publicResolver/operations.js
@@ -8,7 +8,7 @@ import { txTypes } from '../../notifications';
 import { get, set } from '../../factories/operationFactory';
 import abi from './abi.json';
 
-const web3 = new Web3(window.ethereum);
+const web3 = new Web3(window.rLogin);
 const resolver = new web3.eth.Contract(abi, resolverAddress, { gasPrice: defaultGasPrice });
 
 export const getAddr = get(

--- a/src/app/tabs/renew/operations.js
+++ b/src/app/tabs/renew/operations.js
@@ -14,14 +14,14 @@ import { notifyError, notifyTx, txTypes } from '../../notifications';
 export default (domain, tokens, duration) => async (dispatch) => {
   dispatch(requestRenewDomain());
 
-  const durationBN = window.web3.toBigNumber(duration);
+  const web3 = new Web3(window.rLogin);
+  const durationBN = web3.toBigNumber(duration);
   const weiValue = tokens * (10 ** 18);
   const accounts = await window.ethereum.enable();
   const currentAddress = accounts[0];
 
   const data = getRenewData(domain, durationBN);
 
-  const web3 = new Web3(window.ethereum);
   const rif = new web3.eth.Contract(
     abi, rifAddress, { from: currentAddress, gasPrice: defaultGasPrice },
   );

--- a/src/app/tabs/stringResolver/operations.js
+++ b/src/app/tabs/stringResolver/operations.js
@@ -8,7 +8,7 @@ import { txTypes } from '../../notifications';
 import { get, set } from '../../factories/operationFactory';
 import abi from './abi.json';
 
-const web3 = new Web3(window.ethereum);
+const web3 = new Web3(window.rLogin);
 const resolver = new web3.eth.Contract(abi, resolverAddress, { gasPrice: defaultGasPrice });
 
 export const getStr = get(


### PR DESCRIPTION
Fixes and issue that is causing the RNS Manager to break in production.

With the older admin, when a user would log into a domain, it would check against the domain's resolver to see if it was registered with the publicResolver. If so, it would dispatch a message to the notifications resolver, which was never implemented into the new admin.

This older code was using `window.web3` which is no longer provided by MetaMask. Updating this code to use the existing [getDomainResolver()](https://github.com/rnsdomains/rns-manager-react/blob/develop/src/app/tabs/newAdmin/resolver/operations.js#L63-L75) function resulted in a dependency cycle.  Since the notifications are no longer used, it was determined to remove this function and the references to it.

In addition, there was deprecated code still trying to access `window.web3` which is now updated to `window.rlogin`. However, the metamask warning still persists. This is cause for further investigation and issue #367 has been submitted.

For more information, the commits below have detailed descriptions of what was changed.