### PR TITLE
Convert search term to lowercase before searching.

### DIFF
--- a/src/app/tabs/home/components/SearchBoxComponent.js
+++ b/src/app/tabs/home/components/SearchBoxComponent.js
@@ -42,6 +42,7 @@ const SearchBoxComponent = ({ handleClick, strings }) => {
             placeholder={strings.search_placeholder}
             value={search}
             onChange={evt => setSearch(evt.target.value)}
+            autoCapitalize="none"
           />
           <span className="blue">.rsk</span>
         </div>

--- a/src/app/tabs/home/components/SearchBoxComponent.js
+++ b/src/app/tabs/home/components/SearchBoxComponent.js
@@ -21,12 +21,12 @@ const SearchBoxComponent = ({ handleClick, strings }) => {
       return;
     }
 
-    if (isValidName(search) !== null) {
+    if (isValidName(search.toLowerCase()) !== null) {
       setError(strings.invalid_name);
       return;
     }
 
-    handleClick(search);
+    handleClick(search.toLowerCase());
   };
 
   const handleSearchEnter = (e) => {

--- a/src/app/tabs/home/components/SearchBoxComponent.test.js
+++ b/src/app/tabs/home/components/SearchBoxComponent.test.js
@@ -54,4 +54,18 @@ describe('SearchBoxComponent', () => {
 
     expect(handleClick).toBeCalledTimes(0);
   });
+
+  it('converts uppercase to lower when searching', () => {
+    const handleClick = jest.fn();
+    const component = mount(
+      <Provider store={store}>
+        <SearchBoxComponent handleClick={handleClick} />
+      </Provider>,
+    );
+
+    component.find('input').simulate('change', { target: { value: 'UPPERCASEDOMAIN' } });
+    component.find('button').simulate('click');
+
+    expect(handleClick).toBeCalledWith('uppercasedomain');
+  });
 });

--- a/src/app/tabs/home/components/__snapshots__/SearchBoxComponent.test.js.snap
+++ b/src/app/tabs/home/components/__snapshots__/SearchBoxComponent.test.js.snap
@@ -42,6 +42,7 @@ exports[`SearchBoxComponent renders and matches snapshot 1`] = `
             className="col-md-7 col-lg-7 offset-lg-1 searchInput"
           >
             <input
+              autoCapitalize="none"
               onChange={[Function]}
               placeholder="Find your domain"
               value=""

--- a/src/assets/css/sass/_bootstrapReset.scss
+++ b/src/assets/css/sass/_bootstrapReset.scss
@@ -3,3 +3,7 @@ button:hover {
   font-weight: 500 !important;
   border: 1px solid $gray !important;
 }
+
+button:focus {
+  outline: none;
+}

--- a/src/assets/css/sass/home/_searchBox.scss
+++ b/src/assets/css/sass/home/_searchBox.scss
@@ -19,6 +19,10 @@
       text-align: center;
     }
 
+    input:focus {
+      outline: none;
+    }
+
     span {
       display: inline-block;
       width: 10%;


### PR DESCRIPTION
- Converts the search term to lowercase before searching. Resolves #337 
- Removes auto-capitalization for mobile devices. Resolves #251
- Removes outline on landing search boxfocus`. Also removes the same outline for buttons. Resolves UX Feedback No.4
